### PR TITLE
Fix private name resolution in @events

### DIFF
--- a/src/cs_events/_events.py
+++ b/src/cs_events/_events.py
@@ -161,7 +161,7 @@ def _create_init(cls: _T, prefix: str, /) -> _T:
 def _create_events(cls: _T, prefix: str, collection: str, /) -> _T:
     # Assume collection is a valid identifier
     if len(collection) > 2 and collection[:2] == "__" and collection[-2:] != "__":
-        collection = f"_{cls.__name__}{collection}"
+        collection = f"_{cls.__name__.lstrip('_')}{collection}"
 
     locals = {}
     exec(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -130,3 +130,23 @@ def test_events_properties() -> None:
     args, kwargs = (83261, "hi", [0, False]), {"a": 1, "b": None}
     event3_handler1.assert_called_once_with(*args, **kwargs)
     event3_handler2.assert_called_once_with(*args, **kwargs)
+
+
+def test_events_properties_private() -> None:
+    @events(collection="__events")
+    class _Test:
+        e: event[[]]
+
+        def __init__(self) -> None:
+            self.__events = EventHandlerList()
+
+    _Test().e += lambda: None
+
+    @events(collection="__events")
+    class __Test:
+        e: event[[]]
+
+        def __init__(self) -> None:
+            self.__events = EventHandlerList()
+
+    __Test().e += lambda: None


### PR DESCRIPTION
The leading underscores of the class name is stripped for private variable name mangling.